### PR TITLE
Update to use node24 to address deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ branding:
   icon: check-square
   color: blue
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
Github will be deprecating node 20 in actions this summer:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/